### PR TITLE
fix(msg): stamp agent display names in [from …] envelopes (0.40.46)

### DIFF
--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -3,6 +3,16 @@
 User-facing highlights of recent updates. See `release-notes-X.Y.Z.md`
 files in the repo root for the full developer-facing changelog.
 
+## 0.40.46 — Agent-to-agent messages show names again
+
+- **`[from Elon]`, not `[from <uuid>]`.** When agents message each other,
+  the live envelope now uses the workspace agent **display name**
+  (`AGENT.md` / workspace name) instead of the project or session UUID
+  that some sessions mint as their technical address. Cross-workspace
+  **trust is unchanged**: delivery still requires a scoped session plus a
+  local connection (0.40.45 C2). The name is a convenience label, not a
+  capability — connections are the gate.
+
 ## 0.40.45 — Safer agent mail, cleaner terminals, smoother painting
 
 Agents get clearer boundaries on mail and messaging — and the terminal

--- a/crates/k2-daemon/src/caller_workspace.rs
+++ b/crates/k2-daemon/src/caller_workspace.rs
@@ -185,11 +185,44 @@ pub fn request_principal() -> Option<HookPrincipal> {
 /// (e.g. pure unit tests of param maps).
 pub const PRINCIPAL_BOUND_KEY: &str = "principal_bound";
 
+/// Resolve the **display** label for a scoped principal's `[from …]` stamp.
+///
+/// C2 (0.40.45+) peer trust is `HookPrincipal::workspace_uuid` + local
+/// connections — never the free-text `from` string. The envelope is
+/// convenience for humans/agents reading a PTY. Prefer the workspace
+/// agent display name (`AGENT.md` → `projects.name`); fall back to the
+/// mint-time `agent_address` only when the workspace cannot be resolved
+/// (empty uuid, missing projects row). That fallback still covers older
+/// principals whose address was a friendly name, and avoids blank stamps.
+fn display_from_for_principal(principal: &HookPrincipal) -> String {
+    let uuid = principal.workspace_uuid.trim();
+    if !uuid.is_empty() {
+        if let Some(path) = crate::workspace_msg::resolve_workspace(uuid) {
+            let name = k2_core::workspace::display::agent_display_name(&path);
+            if !name.trim().is_empty() {
+                return name;
+            }
+        }
+    }
+    let addr = principal.agent_address.trim();
+    if !addr.is_empty() {
+        return principal.agent_address.clone();
+    }
+    "external".to_string()
+}
+
 /// Stamp server-side caller identity into a params map.
 ///
-/// Overwrites `from`, `project_id`, and (when the principal's workspace
-/// resolves) `project` / `project_path`. Sets [`PRINCIPAL_BOUND_KEY`].
+/// Overwrites `from` (display label), `project_id` (trust / peer-gate
+/// subject), and (when the principal's workspace resolves) `project` /
+/// `project_path`. Sets [`PRINCIPAL_BOUND_KEY`].
 /// Recipient/routing args (`workspace` / `target`) are left untouched.
+///
+/// **`from` is not proof of identity.** Peer messaging is gated on
+/// `workspace_uuid` + connections (C2). `from` is the human-readable
+/// agent/workspace name so live injects render as `[from Elon]` rather
+/// than `[from <project-uuid>]` when the mint-time `agent_address` was
+/// the pinned-chat project id.
 ///
 /// Shared by the cell UDS server and the HTTP mail/DNS arms so identity
 /// stamping is not unix-only.
@@ -197,7 +230,7 @@ pub fn stamp_principal(
     params: &mut std::collections::HashMap<String, String>,
     principal: &HookPrincipal,
 ) {
-    params.insert("from".to_string(), principal.agent_address.clone());
+    params.insert("from".to_string(), display_from_for_principal(principal));
     params.insert("project_id".to_string(), principal.workspace_uuid.clone());
     params.insert(PRINCIPAL_BOUND_KEY.to_string(), "1".to_string());
 
@@ -410,5 +443,59 @@ mod tests {
 
         cleanup(a_id);
         cleanup(b_id);
+    }
+
+    /// 0.40.46: when the mint-time `agent_address` is the project UUID
+    /// (pinned-chat keying), the display stamp must still be the
+    /// workspace name — not the UUID. Peer trust stays on workspace_uuid.
+    #[test]
+    fn stamp_from_uses_workspace_display_name_not_project_uuid() {
+        let _ = k2_core::db::init_for_tests();
+        let id = "56565656-5656-5656-5656-565656565656";
+        let path = "/tmp/k2-caller-ws-Elon";
+        seed_project(id, path, "Elon");
+
+        let principal = HookPrincipal {
+            workspace_uuid: id.to_string(),
+            // Mimic v2 pinned-chat mint: agent_address == project id.
+            agent_address: id.to_string(),
+        };
+        let mut params = HashMap::new();
+        params.insert("from".to_string(), "FORGED-ATTACKER".to_string());
+        stamp_principal(&mut params, &principal);
+
+        assert_eq!(
+            params.get("from").map(String::as_str),
+            Some("Elon"),
+            "from stamp must be the workspace display name, not the project UUID"
+        );
+        assert_eq!(
+            params.get("project_id").map(String::as_str),
+            Some(id),
+            "peer-gate subject remains the workspace uuid"
+        );
+        assert_ne!(
+            params.get("from").map(String::as_str),
+            Some(id),
+            "must not leak the project UUID into the display envelope"
+        );
+
+        cleanup(id);
+    }
+
+    #[test]
+    fn stamp_from_falls_back_to_agent_address_when_unresolvable() {
+        let _ = k2_core::db::init_for_tests();
+        let principal = HookPrincipal {
+            workspace_uuid: "99999999-9999-9999-9999-999999999999".to_string(),
+            agent_address: "orphan-agent".to_string(),
+        };
+        let mut params = HashMap::new();
+        stamp_principal(&mut params, &principal);
+        assert_eq!(
+            params.get("from").map(String::as_str),
+            Some("orphan-agent"),
+            "unresolvable principal still stamps mint-time agent_address"
+        );
     }
 }

--- a/crates/k2-daemon/src/cell_server.rs
+++ b/crates/k2-daemon/src/cell_server.rs
@@ -946,7 +946,13 @@ mod unix_impl {
                 Some(ws_path),
                 "body `project_path` must be FORCED to the principal's own workspace"
             );
-            assert_eq!(params.get("from").map(String::as_str), Some("agent-W"));
+            // 0.40.46: display stamp is workspace name ("W"), not mint-time
+            // agent_address ("agent-W"). Peer trust still uses project_id.
+            assert_eq!(params.get("from").map(String::as_str), Some("W"));
+            assert_eq!(
+                params.get("project_id").map(String::as_str),
+                Some(ws_uuid)
+            );
 
             // Fail-closed: an unresolvable principal REMOVES both keys even
             // when the body supplied them.

--- a/crates/k2-daemon/src/mail/routes_messages.rs
+++ b/crates/k2-daemon/src/mail/routes_messages.rs
@@ -168,15 +168,17 @@ fn resolve_linked_password(
     }
 }
 
-/// Client `from` filter for messages/wait — NOT the identity stamp.
+/// Client `from` filter for messages/wait — NOT the identity / display stamp.
 ///
-/// Wave 0 / dual-auth `stamp_principal` writes the agent address into
-/// `from=`. Mail list/wait treat `from` as an IMAP/JMAP From: substring
-/// filter. Under a scoped passport that became `FROM "<workspace-uuid>"`
-/// and always returned empty while folder list (no filter) still worked
-/// (#38 agent AKZM retest). Dispatcher restores client --from after stamp;
-/// this belt also drops a remaining stamp when `principal_bound` is set
-/// and `from` equals the stamped `project_id` (common agent_address shape).
+/// Wave 0 / dual-auth `stamp_principal` writes a display label into `from=`
+/// (workspace agent name since 0.40.46; historically often the project
+/// uuid when mint-time `agent_address` was the pinned-chat id). Mail
+/// list/wait treat `from` as an IMAP/JMAP From: substring filter. Under a
+/// scoped passport that pollution became `FROM "<stamp>"` and returned
+/// empty while folder list (no filter) still worked (#38 agent AKZM
+/// retest). Dispatcher restores client --from after stamp; this belt also
+/// drops a remaining stamp when `principal_bound` is set and `from`
+/// equals the stamped `project_id` (legacy uuid-shaped stamp).
 fn mail_from_filter(params: &HashMap<String, String>) -> Option<String> {
     let from = crate::cli::opt_param(params, "from")?;
     if params.get("principal_bound").map(|s| s == "1").unwrap_or(false) {

--- a/crates/k2-daemon/src/routes/dispatcher.rs
+++ b/crates/k2-daemon/src/routes/dispatcher.rs
@@ -4632,13 +4632,14 @@ async fn handle_one_request(
                 .await;
                 return DispatchOutcome::Done;
             }
-            // #38: stamp_principal writes identity into `from=` (agent
-            // address / workspace uuid). Mail `messages` / `wait` treat
-            // `from` as an IMAP/JMAP From: filter — so a scoped agent
-            // silently searched FROM "<principal>" and always got empty
-            // while folder list (no from filter) still worked.
-            // Capture the client filter BEFORE stamp; restore after.
-            // Absent client --from → remove stamp pollution so no filter.
+            // #38: stamp_principal writes a display label into `from=`
+            // (workspace agent name; peer trust is project_id / uuid).
+            // Mail `messages` / `wait` treat `from` as an IMAP/JMAP From:
+            // filter — so a scoped agent silently searched FROM
+            // "<stamp>" and always got empty while folder list (no from
+            // filter) still worked. Capture the client filter BEFORE
+            // stamp; restore after. Absent client --from → remove stamp
+            // pollution so no filter.
             let client_from_filter = params
                 .get("from")
                 .cloned()

--- a/crates/k2-daemon/src/workspace_routes.rs
+++ b/crates/k2-daemon/src/workspace_routes.rs
@@ -280,9 +280,10 @@ pub fn dispatch(path: &str, params: &HashMap<String, String>) -> Option<CliRespo
         "/cli/workspace/msg" => {
             let workspace = str_param(params, "workspace");
             let text = str_param(params, "text");
-            // C2: display `from` may be free-text for humans, but PEER
-            // IDENTITY is the stamped principal (or owner bypass) — never
-            // free-text `--from` as the gate subject.
+            // C2: PEER IDENTITY is the stamped principal's workspace_uuid
+            // (or owner bypass) + connections — never free-text `--from`.
+            // After stamp, `from` is the workspace agent display name
+            // (0.40.46); client `--from` is overwritten on scoped paths.
             let from = opt_param(params, "from").unwrap_or_default();
             // 0.39.25: optional slash-command prepended at the very front
             // of the delivered payload (before the `[from <name>]`

--- a/crates/k2-daemon/tests/cell_server_uds_integration.rs
+++ b/crates/k2-daemon/tests/cell_server_uds_integration.rs
@@ -331,9 +331,15 @@ async fn case6b_inbox_compose_stamps_principal_from_durably() {
         !rbody.contains("FORGED-ATTACKER"),
         "stored memo must NOT carry the forged from; body={rbody}"
     );
+    // 0.40.46: display stamp is the workspace name ("wsc"), not mint-time
+    // agent_address ("agent-c3"). The body cannot forge either.
     assert!(
-        rbody.contains("agent-c3"),
-        "stored memo must carry the principal-stamped from (agent-c3); body={rbody}"
+        rbody.contains("wsc"),
+        "stored memo must carry the workspace display name as from (wsc); body={rbody}"
+    );
+    assert!(
+        !rbody.contains("agent-c3"),
+        "mint-time agent_address must not be preferred over display name when the workspace resolves; body={rbody}"
     );
 }
 


### PR DESCRIPTION
## Summary

Agent-to-agent `k2 msg` injects were showing session/project UUIDs in the live envelope (`[from fb3d6945-…]`) instead of workspace names (`[from Elon]`).

**Root cause:** On scoped (cell UDS) paths, `stamp_principal` overwrites client `from=` with `HookPrincipal.agent_address`. Pinned-chat mints often set `agent_address` to the **project UUID**, so the display stamp became a UUID.

**Trust model (unchanged, C2 / 0.40.45):** Peer delivery is gated on `workspace_uuid` + local connections — not the free-text `[from …]` string. The envelope is a **convenience label**, not a capability. Names were always available via `agent_display_name` / `projects.name`.

## Fix

- Resolve `from` via `agent_display_name(workspace_path)` when the principal’s workspace resolves
- Keep `project_id` = `workspace_uuid` as the peer-gate subject
- Fall back to mint-time `agent_address` only if the workspace cannot be resolved
- Client `--from` remains overwritten on scoped paths (display comes from the principal’s workspace name)

## Test plan

- [x] Unit: `stamp_from_uses_workspace_display_name_not_project_uuid` (agent_address == project UUID → `from` is workspace name)
- [x] Unit: unresolvable principal falls back to mint-time `agent_address`
- [x] Updated cell_server stamp force test to expect display name `"W"`
- [x] Updated UDS integration inbox compose attribution to expect workspace name `"wsc"`
- [ ] CI: `cargo test -p k2-daemon`
- [ ] Manual (post-release): two connected agents `k2 msg` each other → envelopes show names; disconnect → still 403 `not_connected`

## Release

Target **0.40.46**. `WHATS_NEW.md` entry added.